### PR TITLE
fix: skip search pre-initialization during static rendering so genera…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # unreleased
 
 - change: make upper maturity-pyramid labels progressively smaller to reinforce depth in the dashboard
+- fix: skip search pre-initialization during static rendering so generated HTML pages do not inline the FlexSearch bundle in the head
 
 ## 0.27.1 (2026-06-07)
 

--- a/src/app-mode/app-init.ts
+++ b/src/app-mode/app-init.ts
@@ -11,6 +11,7 @@ import SearchHistory from '@search/search-history'
 import dbSchema from '@src/assets/db-schema.json'
 import { checkLocalEditStatus } from '@src/local-edit/local-edit-config'
 import { localEditStatus } from '@lib/store'
+import { isStaticMode } from '@lib/url'
 import type { SearchHistoryEntry } from '@search/search-history'
 import type { Favorite } from '@favorite/favorites'
 import type { ConfigFilter, Log } from '@src/type'
@@ -66,10 +67,12 @@ export function initApp(): Promise<void> {
           )
         })
       }
-      if ('requestIdleCallback' in window) {
-        window.requestIdleCallback(scheduleSearchInit)
-      } else {
-        setTimeout(scheduleSearchInit, 0)
+      if (!isStaticMode) {
+        if ('requestIdleCallback' in window) {
+          window.requestIdleCallback(scheduleSearchInit)
+        } else {
+          setTimeout(scheduleSearchInit, 0)
+        }
       }
 
       stepTimer = performance.now()


### PR DESCRIPTION
…ted HTML pages do not inline the FlexSearch bundle in the head